### PR TITLE
Fix arguments and modify dump method

### DIFF
--- a/ficmgr.py
+++ b/ficmgr.py
@@ -462,7 +462,7 @@ class ficmanage:
             print("ERROR: You must specify target.", file=sys.stderr)
             return -1
 
-        target = self.get_target()
+        targets = self.get_target()
 
         cmd = self.args.hlscmd[0]
         if cmd not in ['start', 'reset']:
@@ -471,12 +471,12 @@ class ficmanage:
 
         procs = []
         q = Queue()
-        def proc(q, cmd):
-            ret = self.fic_hls_cmd(cmd)
+        def proc(q, target, cmd):
+            ret = self.fic_hls_cmd(target, cmd)
             q.put((target, ret))
 
         for t in targets:
-            p = Process(target=proc, args=(q, cmd))
+            p = Process(target=proc, args=(q, t, cmd))
             procs.append(p)
             p.start()
 
@@ -748,7 +748,7 @@ class ficmanage:
             url =  BOARDS[target]['url'] + '/hls'
             print("INFO: Send HLS command to {0:s}".format(target))
 
-            j = json.dump({
+            j = json.dumps({
                 'command': cmd,
             })
 


### PR DESCRIPTION
@nyacom 
HLSのreset,startコマンドを実行するメソッド内で
- target boardのリストを示す変数名の統一
- fic_hls_cmdの変数の追加
- jsonのdumpメソッドをdumpsへ変更(dumpはファイルオブジェクトが必要らしい)

を行いました。
```
Namespace(hlscmd=['reset'], hlsrecv=None, hlssend=None, list=False, message=None, prog=None, progmode=None, regread=None, regwrite=None, reset=False, runcmd=None, runcmdtimeout=None, switchset=None, target=['fic01', 'fic02'])
ficmanager nyacom (C) December, 2018

INFO: Send HLS command to fic01
INFO: Send HLS command to fic02
INFO: HLS send command on fic02 failed
INFO: HLS send command on fic01 failed
```
しかしfailedが返ってくる...
retのreturnキーってどこでsuccessになるんでしょうか...